### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,6 +9,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:   
   build-artifact:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/QBos07/HHK3template/security/code-scanning/1](https://github.com/QBos07/HHK3template/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used (`actions/checkout@v4` and `actions/upload-artifact@v4`), the workflow likely only requires `contents: read` and possibly `packages: write` or `actions: write` for uploading artifacts. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-artifact`) to limit permissions to that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
